### PR TITLE
Added compatibility with camel case anemic getters

### DIFF
--- a/src/LIN3S/AdminBundle/Twig/TwigFilterPathFunction.php
+++ b/src/LIN3S/AdminBundle/Twig/TwigFilterPathFunction.php
@@ -76,6 +76,17 @@ class TwigFilterPathFunction extends \Twig_Extension
      */
     public function filterPath($field, $currentOrderBy, $currentOrder = 'ASC')
     {
+        $properties = explode('.', $field);
+
+        foreach ($properties as &$property) {
+            if (substr($property, 0, strlen('get')) == 'get') {
+                $property = substr($property, strlen('get'));
+                $property = lcfirst($property);
+            }
+        }
+
+        $properties = implode('.', $properties);
+        
         $request = $this->requestStack->getMasterRequest();
         if ($currentOrderBy === $field) {
             $currentOrder = $currentOrder === 'DESC' ? 'ASC' : 'DESC';


### PR DESCRIPTION
StringListFieldType is compatible with properties and functions notated by dot separator, however, if the field name is an anemic getter, Doctrine fails fetching the property from database.

The proposed solution checks if the field contains an anemic getter and suppress the starting get and lowerize the first character after the get.